### PR TITLE
test: fix tests running on GHA

### DIFF
--- a/src/__tests__/__snapshots__/index.spec.ts.snap
+++ b/src/__tests__/__snapshots__/index.spec.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`@continuous-auth/client should throw an error on an unsupported CI platform 1`] = `[Error: Unsupported CI provider, currently we only support CircleCI and TravisCI]`;
+exports[`@continuous-auth/client should throw an error on an unsupported CI platform 1`] = `[Error: Unsupported CI provider, currently we only support CircleCI and GitHub Actions]`;
 
 exports[`@continuous-auth/client should throw an error when CFA_PROJECT_ID is not set 1`] = `[Error: Requested env var "CFA_PROJECT_ID" is missing or empty]`;
 

--- a/src/__tests__/index.spec.ts
+++ b/src/__tests__/index.spec.ts
@@ -27,6 +27,7 @@ describe('@continuous-auth/client', () => {
   it('should throw an error on an unsupported CI platform', async () => {
     process.env.CFA_SECRET = 'test';
     process.env.CFA_PROJECT_ID = '123';
+    delete process.env.GITHUB_ACTIONS;
     await expect(getOtp()).rejects.toMatchSnapshot();
   });
 

--- a/src/github.ts
+++ b/src/github.ts
@@ -16,7 +16,7 @@ export const requestThroughGitHubActions = async (
 ): Promise<CFARequest> => {
   const startResponse = await cfaClient.post<CFARequest>(`/api/request/${projectId}/github`, {
     oidcToken: process.env.GITHUB_OIDC_TOKEN,
-    buildUrl: `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`
+    buildUrl: `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`,
   });
 
   if (startResponse.status !== 200) {
@@ -45,7 +45,7 @@ export const requestThroughGitHubActions = async (
     acquireCode = acquireResponse.status;
     if (acquireCode === 200) return acquireResponse.data;
     // Check again in 10 seconds
-    await new Promise(r => setTimeout(r, retryInterval));
+    await new Promise((r) => setTimeout(r, retryInterval));
   }
 
   throw new Error(`Unexpected status code while polling the CFA acquire endpoint: ${acquireCode}`);

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,7 +42,7 @@ export const validateConfiguration = async () => {
   } else if (process.env.GITHUB_ACTIONS) {
     slug = 'github';
   } else {
-    throw new Error('Unsupported CI provider, currently we only support CircleCI');
+    throw new Error('Unsupported CI provider, currently we only support CircleCI and GitHub Actions');
   }
 
   const response = await cfaClient.post(`/api/request/${CFA_PROJECT_ID}/${slug}/test`, {
@@ -67,6 +67,6 @@ export const getOtp = async () => {
     const request = await requestThroughGitHubActions(cfaClient, CFA_PROJECT_ID);
     return request.response;
   } else {
-    throw new Error('Unsupported CI provider, currently we only support CircleCI and TravisCI');
+    throw new Error('Unsupported CI provider, currently we only support CircleCI and GitHub Actions');
   }
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,7 +42,9 @@ export const validateConfiguration = async () => {
   } else if (process.env.GITHUB_ACTIONS) {
     slug = 'github';
   } else {
-    throw new Error('Unsupported CI provider, currently we only support CircleCI and GitHub Actions');
+    throw new Error(
+      'Unsupported CI provider, currently we only support CircleCI and GitHub Actions',
+    );
   }
 
   const response = await cfaClient.post(`/api/request/${CFA_PROJECT_ID}/${slug}/test`, {
@@ -67,6 +69,8 @@ export const getOtp = async () => {
     const request = await requestThroughGitHubActions(cfaClient, CFA_PROJECT_ID);
     return request.response;
   } else {
-    throw new Error('Unsupported CI provider, currently we only support CircleCI and GitHub Actions');
+    throw new Error(
+      'Unsupported CI provider, currently we only support CircleCI and GitHub Actions',
+    );
   }
 };


### PR DESCRIPTION
Follow-up to 3d70d6bcd92f0f3aca541d1ef597eff325fa3e40 which started failing CI because it now supports GHA, so the test for an unsupported CI platform was no longer accurate.

Also fixes lint.